### PR TITLE
pretty sure these id's etc. were wrong

### DIFF
--- a/client/components/charts/charts.directives.js
+++ b/client/components/charts/charts.directives.js
@@ -1338,7 +1338,7 @@ app.directive('interfaceChart', ['Report', '$routeParams', '$timeout', 'gettextC
         } else {
           opts.height = 250;
         }
-        c = new window.google.visualization.LineChart(document.getElementById('mcs-chart'));
+        c = new window.google.visualization.LineChart(document.getElementById('snr-chart'));
         c.draw(data, opts);
         scope.noData = undefined;
         scope.loading = undefined;

--- a/client/components/charts/devices/_snr_chart.html
+++ b/client/components/charts/devices/_snr_chart.html
@@ -8,7 +8,7 @@
     <md-button class="md-icon-button" ng-if="fs" ng-click="fullScreen()">
       <md-icon>fullscreen_exit</md-icon>
     </md-button>
-    <md-button class="md-icon-button" ng-if="!fs" ng-click="fullScreen('mcs')">
+    <md-button class="md-icon-button" ng-if="!fs" ng-click="fullScreen('snr')">
       <md-icon>fullscreen</md-icon>
     </md-button>
     <md-button class="md-icon-button" ng-click="refresh()">
@@ -53,7 +53,7 @@
     </md-menu-bar>
   </md-card-header>
   <md-card-content>
-    <div id="mcs-chart"></div>
+    <div id="snr-chart"></div>
     <div>
       <div layout="row" ng-if="noData || loading" style="min-height: 250px;" layout-align="left end" class="muted">
         <p><small><span ng-if="noData" translate>No graph data</span><span ng-if="loading" translate>Loading usage data</span></small></p>


### PR DESCRIPTION
the fullscreen function was changed to show the mcs chart instead of snr in pr #516 
i think it should be snr but so should the references in the directive