### PR TITLE
only set language when necessary

### DIFF
--- a/client/components/services/users.services.js
+++ b/client/components/services/users.services.js
@@ -213,8 +213,16 @@ app.factory('Translate', ['$cookies', 'gettextCatalog', 'amMoment', function($co
   }
 
   function setLanguage() {
-    for (var i = 0;  language === undefined && navigator.languages !== null && i < navigator.languages.length; ++i) {
-      var lang = navigator.languages[i].substr(0, 2);
+    if (navigator.languages) {
+      for (var i = 0;  language === undefined && navigator.languages !== null && i < navigator.languages.length; ++i) {
+        var lang = navigator.languages[i].substr(0, 2);
+        language = fixLocale(lang);
+        if (supported[lang]) {
+          language = lang;
+        }
+      }
+    } else {
+      var lang = navigator.language.substr(0, 2);
       language = fixLocale(lang);
       if (supported[lang]) {
         language = lang;
@@ -231,7 +239,7 @@ app.factory('Translate', ['$cookies', 'gettextCatalog', 'amMoment', function($co
     //if the cookie is empty try if one of
     //the user's browser language preferences
     //is supported
-    if (language === undefined && !navigator.language) {
+    if (language === undefined) {
       setLanguage();
     }
 

--- a/client/components/services/users.services.js
+++ b/client/components/services/users.services.js
@@ -231,7 +231,7 @@ app.factory('Translate', ['$cookies', 'gettextCatalog', 'amMoment', function($co
     //if the cookie is empty try if one of
     //the user's browser language preferences
     //is supported
-    if (language === undefined) {
+    if (language === undefined && !navigator.language) {
       setLanguage();
     }
 


### PR DESCRIPTION
the ios browser doesn't seem to have .languages, as it already seems to have a language set.

it was therefore breaking inside the setLanguage() function, when trying to evaluate navigator.languages - there also doesn't appear to be any need for the setLanguage() function when using iOS