### PR TITLE
load charts dependencies in head ISSUES-103

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -45,6 +45,12 @@
 
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
+  <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+
+  <script type="text/javascript">
+    window.google.charts.load('current', {'packages':['corechart']});
+  </script>
+
   <style type="text/css">
     [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
       display: none !important;
@@ -444,7 +450,6 @@
   <script src="components/webhooks/webhooks.directives.js"></script>
   <script src="components/webhooks/webhooks.services.js"></script>
   <script src="scripts/config.js"></script>
-  <!-- <script src="scripts/highlight.pack.js"></script> -->
   <!-- endinjector -->
   <!-- endbuild -->
 
@@ -484,12 +489,6 @@
         });
       }
     });
-  </script>
-
-  <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-
-  <script type="text/javascript">
-    window.google.charts.load('current', {'packages':['corechart']});
   </script>
 
   <script type="text/javascript" src="//maps.googleapis.com/maps/api/js?key=AIzaSyD243NSdgNYjRHBVBrWoEKX728FYOxuUgE&libraries=visualization"></script>

--- a/client/index.html
+++ b/client/index.html
@@ -450,6 +450,7 @@
   <script src="components/webhooks/webhooks.directives.js"></script>
   <script src="components/webhooks/webhooks.services.js"></script>
   <script src="scripts/config.js"></script>
+  <!-- <script src="scripts/highlight.pack.js"></script> -->
   <!-- endinjector -->
   <!-- endbuild -->
 


### PR DESCRIPTION
Appears to fix the issue locally, but its so sporadic on a local build its hard to tell. This pull just brings the charts related script up into the head slightly speeding up the load of these libraries relative to the page load.