### PR TITLE
moment timezone version specified

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "google-chart": "~1.0.4",
     "moment-duration-format": "~1.3.0",
     "angular-gettext": "~2.2.1",
-    "moment-timezone": "~0.5.4",
+    "moment-timezone": "0.5.11",
     "angular-scroll-glue": "^2.1.0",
     "angular-animate": "~1.5.*",
     "emojionearea": "^3.1.6"


### PR DESCRIPTION
in the latest build moment uses 0.5.12, forcing it to .11