### PR TITLE
fix: network cleared on splash page change

### DIFF
--- a/client/components/splash_pages/splash_pages.directives.js
+++ b/client/components/splash_pages/splash_pages.directives.js
@@ -423,7 +423,7 @@ app.directive('locationSplashPagesShow', ['SplashPage', 'Location', '$routeParam
         scope.access_name();
 
         scope.networks = results.networks;
-        scope.splash.networks = [];
+        //scope.splash.networks = [];
 
         createMenu();
         scope.loading = undefined;

--- a/client/components/splash_pages/splash_pages.directives.js
+++ b/client/components/splash_pages/splash_pages.directives.js
@@ -364,6 +364,7 @@ app.directive('locationSplashPagesShow', ['SplashPage', 'Location', '$routeParam
       $scope.loading = undefined;
 
       $scope.update = function() {
+        $scope.splash.networks = [];
         for (var i = 0; i < $scope.selected.length; i++) {
           $scope.splash.networks.push($scope.selected[i].id);
         }


### PR DESCRIPTION
Currently, when you save the changes you made to a splash page, the previously assigned network will be lost. This fixes that bug.