### PR TITLE
Fixed translation of md-buttons

### DIFF
--- a/client/components/networks/_self_destruct.html
+++ b/client/components/networks/_self_destruct.html
@@ -36,11 +36,11 @@
     </md-dialog-content>
     <md-dialog-actions layout="row">
       <span flex="auto"></span>
-      <md-button ng-click="close()" translate>
-        Close
+      <md-button ng-click="close()">
+        <translate>Close<translate>
       </md-button>
-      <md-button class="md-raised"ng-click="save()" translate>
-        CREATE
+      <md-button class="md-raised"ng-click="save()">
+        <translate>CREATE</translate>
       </md-button>
     </md-dialog-actions>
   </form>


### PR DESCRIPTION
The "translate" attribute does not work correctly on md-* elements like `<md-button>`, please use it separately instead.