### PR TITLE
send zero if no outbound api data

### DIFF
--- a/client/components/charts/charts.directives.js
+++ b/client/components/charts/charts.directives.js
@@ -490,7 +490,12 @@ app.directive('txChart', ['$timeout', 'Report', '$routeParams', 'gettextCatalog'
           for(var i = 0; i < json.data[0].data.length; i++) {
             time = new Date(s1[i].timestamp*1000);
             var inbound = (s1[i].value / (1000)) * 8;
-            var outbound = (s2[i].value / (1000)) * 8;
+            var outbound;
+            if (s2[i]) {
+              outbound = (s2[i].value / (1000)) * 8;
+            } else {
+              outbound = 0;
+            }
             data.addRow([time, null, inbound, outbound]);
           }
         }


### PR DESCRIPTION
there's quite often one less piece of data for outbound than for inbound for periods 1d, 7d and 30d so this stops the graph from breaking but i'm not sure if there's something we can fix in the backend to actually fix the root cause?